### PR TITLE
Adding link support

### DIFF
--- a/code.js
+++ b/code.js
@@ -181,9 +181,13 @@ function processText(item, output) {
       var startPos = indices[i];
       var endPos = i+1 < indices.length ? indices[i+1]: text.length;
       var partText = text.substring(startPos, endPos);
+      var mylink = item.getLinkUrl(startPos);
 
       Logger.log(partText);
 
+      if (partAtts.LINK_URL) {
+        output.push('<a href="' + mylink + '">');
+      }
       if (partAtts.ITALIC) {
         output.push('<i>');
       }
@@ -216,7 +220,9 @@ function processText(item, output) {
       if (partAtts.UNDERLINE) {
         output.push('</u>');
       }
-
+      if (partAtts.LINK_URL) {
+        output.push('</a>');
+      }
     }
   }
 }


### PR DESCRIPTION
Hey Omar—as far as I could tell, GoogleDoc2HTML didn't support in-line links. Using Google's getlinkUrl() and partAtts.LINK_URL, I managed to in-line it without too much trouble.
