### PR TITLE
Remove incorrect </ul> after first item of lists

### DIFF
--- a/code.js
+++ b/code.js
@@ -100,10 +100,7 @@ function processItem(item, listCounters, images) {
           || gt === DocumentApp.GlyphType.HOLLOW_BULLET
           || gt === DocumentApp.GlyphType.SQUARE_BULLET) {
         prefix = '<ul class="small"><li>', suffix = "</li>";
-
-          suffix += "</ul>";
-        }
-      else {
+      } else {
         // Ordered list (<ol>):
         prefix = "<ol><li>", suffix = "</li>";
       }


### PR DESCRIPTION
The code used to add a \</ul\> after the first list item of unordered lists. This change removes that. The lists are still closed correctly by a different \</ul\> later.